### PR TITLE
fix: ignore attestations in remote platform verification

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -256,10 +256,7 @@ jobs:
             inspect_output="$(docker buildx imagetools inspect "$image_ref")"
             printf '%s\n' "$inspect_output" > "$output_file"
 
-            printf '%s\n' "$inspect_output" \
-              | sed -n 's/^[[:space:]]*Platform:[[:space:]]*//p' \
-              | sort -u \
-              | paste -sd, -
+            printf '%s\n' "$inspect_output" | ./scripts/extract-imagetools-platforms.sh
           }
 
           IFS=',' read -r -a platforms <<< "${{ steps.resolved.outputs.resolved_platforms }}"

--- a/scripts/extract-imagetools-platforms.sh
+++ b/scripts/extract-imagetools-platforms.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -gt 1 ]]; then
+  echo "用法: $0 [inspect_output_file]" >&2
+  exit 1
+fi
+
+if [[ $# -eq 1 ]]; then
+  input_stream=$(cat "$1")
+else
+  input_stream=$(cat)
+fi
+
+printf '%s\n' "$input_stream" \
+  | awk '
+      /^[[:space:]]*Platform:[[:space:]]*/ {
+        sub(/^[[:space:]]*Platform:[[:space:]]*/, "", $0)
+        if ($0 != "" && $0 != "unknown/unknown") {
+          print $0
+        }
+      }
+    ' \
+  | sort -u \
+  | paste -sd, -

--- a/scripts/test-extract-imagetools-platforms.sh
+++ b/scripts/test-extract-imagetools-platforms.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT_PATH="$ROOT_DIR/scripts/extract-imagetools-platforms.sh"
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [[ "$expected" != "$actual" ]]; then
+    echo "断言失败: $message" >&2
+    echo "期望: $expected" >&2
+    echo "实际: $actual" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -x "$SCRIPT_PATH" ]]; then
+  echo "缺少待测脚本: $SCRIPT_PATH" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat <<'EOF' > "$tmp_dir/single-arch-with-attestation.txt"
+Name:      docker.io/power4j/mvnd:tmp-tag-amd64
+MediaType: application/vnd.oci.image.index.v1+json
+Digest:    sha256:single
+
+Manifests:
+  Name:        docker.io/power4j/mvnd:tmp-tag-amd64@sha256:image
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    linux/amd64
+
+  Name:        docker.io/power4j/mvnd:tmp-tag-amd64@sha256:attestation
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    unknown/unknown
+  Annotations:
+    vnd.docker.reference.digest: sha256:image
+    vnd.docker.reference.type:   attestation-manifest
+EOF
+
+cat <<'EOF' > "$tmp_dir/multi-arch-with-attestation.txt"
+Name:      docker.io/power4j/mvnd:tmp-tag
+MediaType: application/vnd.oci.image.index.v1+json
+Digest:    sha256:multi
+
+Manifests:
+  Name:        docker.io/power4j/mvnd:tmp-tag@sha256:amd64
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    linux/amd64
+
+  Name:        docker.io/power4j/mvnd:tmp-tag@sha256:amd64-attestation
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    unknown/unknown
+  Annotations:
+    vnd.docker.reference.digest: sha256:amd64
+    vnd.docker.reference.type:   attestation-manifest
+
+  Name:        docker.io/power4j/mvnd:tmp-tag@sha256:arm64
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    linux/arm64
+
+  Name:        docker.io/power4j/mvnd:tmp-tag@sha256:arm64-attestation
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    unknown/unknown
+  Annotations:
+    vnd.docker.reference.digest: sha256:arm64
+    vnd.docker.reference.type:   attestation-manifest
+EOF
+
+single_arch_result="$("$SCRIPT_PATH" < "$tmp_dir/single-arch-with-attestation.txt")"
+assert_eq "linux/amd64" "$single_arch_result" "单架构镜像应忽略 attestation 平台"
+
+multi_arch_result="$("$SCRIPT_PATH" < "$tmp_dir/multi-arch-with-attestation.txt")"
+assert_eq "linux/amd64,linux/arm64" "$multi_arch_result" "多架构 manifest 应忽略 attestation 平台"
+
+echo "imagetools 平台提取脚本测试通过"


### PR DESCRIPTION
## Summary
- extract imagetools platform parsing into a script
- ignore attestation-only unknown/unknown platforms during remote verification
- add a shell regression test covering single and multi-arch attestation output

## Verification
- bash scripts/test-resolve-target-platforms.sh
- bash scripts/test-smoke-test-image.sh
- bash scripts/test-extract-imagetools-platforms.sh
- python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/workflows/docker-build.yml").read_text()); yaml.safe_load(pathlib.Path(".github/workflows/ci.yml").read_text()); yaml.safe_load(pathlib.Path(".github/workflows/push-images.yml").read_text())'
- git diff --check
- gh run watch 23525555512 --exit-status